### PR TITLE
Replace CSSParser with PWM Parser

### DIFF
--- a/lib/busylight.js
+++ b/lib/busylight.js
@@ -4,7 +4,7 @@ var HID = require('node-hid')
   , events = require('events')
   , util = require('util')
   , degamma = require('./degamma')
-  , cssColor = require('csscolorparser')
+  , pwmColor = require('pwmcolorparser')
   , Stepper = require('./stepper')
   , tones = {
     OpenOffice        : 136,
@@ -34,7 +34,8 @@ function tweenRGB(start, end, value) {
 }
 
 function getRGB(color) {
-  return cssColor.parseCSSColor(color);
+  console.log(color)
+  return pwmColor.parseColor(color);
 }
 
 function Busylight(options){

--- a/lib/busylight.js
+++ b/lib/busylight.js
@@ -34,7 +34,6 @@ function tweenRGB(start, end, value) {
 }
 
 function getRGB(color) {
-  console.log(color)
   return pwmColor.parseColor(color);
 }
 

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
   ],
   "dependencies": {
     "node-hid": "0.5.x",
-    "csscolorparser": "1.0.2"
+    "pwmcolorparser": "1.1.0"
   },
   "homepage": "http://github.com/porsager/busylight/",
   "bugs": {
-    "url" : "http://github.com/porsager/busylight/issues",
+    "url": "http://github.com/porsager/busylight/issues",
     "email": "rasmus@porsager.com"
   },
   "scripts": {


### PR DESCRIPTION
Busylight works using PWM values to control the light. PWM values work on a scale of 0-100. Currently the busylight node module sets the busylight value using an RGB which works for colors like red [255, 0, 0] because the light interprets anything over 100 as 100. I noticed an issue when trying to create an orange light. Orange's hex code is #FFA500 which translates to [255, 165, 0] which the busylight interprets as yellow [100,100,0]. If you want to light the busylight as orange using the current set up you would need to pass in #644500 -> [100, 65, 0]

I made a change to use a pwmcolorparser library to handle the conversions so the busylight can correctly display the colors. 