### PR TITLE
Add new Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "hid"
   ],
   "dependencies": {
-    "node-hid": "0.5.x",
-    "pwmcolorparser": "1.1.0"
+    "node-hid": "^0.7.2",
+    "pwmcolorparser": "1.1.1"
   },
   "homepage": "http://github.com/porsager/busylight/",
   "bugs": {


### PR DESCRIPTION
Hey,
I've updated your dependencies. 
The old node-hid crashed actually electron (2.0.0) projects.

I've tested this package on Ubuntu 18.04 with node-hid 0.7.2 and pwmcolorparser 1.1.1.
My Busylight still works :)