### PR TITLE
Fix support for some devices

### DIFF
--- a/lib/busylight.js
+++ b/lib/busylight.js
@@ -41,7 +41,7 @@ function Busylight(options){
   events.EventEmitter.call(this);
   this.options = options || supported;
   this.buffer = [0,0,0,0,0,0,0,0,128];
-  this.newProtocol = options.vendorId = 10171
+  this.newProtocol = options.vendorId === 10171;
   this.debug = false;
   this.connectAttempts = 0;
   this.getColorArray = function(colors) {


### PR DESCRIPTION
Devices with deviceId other than 10171 would get its deviceId overwritten with 10171 and the used protocol would always be the newer, thus breaking support for { "vendorId": 1240, "productId": 63560 }.