### PR TITLE
Fix closing of not connected devices

### DIFF
--- a/lib/busylight.js
+++ b/lib/busylight.js
@@ -131,7 +131,13 @@ Busylight.prototype.defaults = function(options){
 };
 
 Busylight.prototype.close = function(){
-  this.device.close();
+  if (this.device) {
+    this.device.close();
+  }
+  if (this.reconnectTimer) {
+    clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = null;
+  }
 };
 
 Busylight.prototype.off = function(){


### PR DESCRIPTION
On close, only close the device if there is one and clear the reconnect timeout.